### PR TITLE
Modified the base url for the server

### DIFF
--- a/PxAPI-2.yml
+++ b/PxAPI-2.yml
@@ -3,7 +3,7 @@ info:
   title: PxApi
   version: '2.0'
 servers:
-  - url: https://api.server.test/v1
+  - url: https://api.server.test/api/v2
 paths:
   /navigation:
       get:


### PR DESCRIPTION
The base url should end with /api/v2 according to the old spec which is in line with the default of the version 1 of the api that ended with /api/v1.