### PR TITLE
Fix for the language being nullable

### DIFF
--- a/PxAPI-2.yml
+++ b/PxAPI-2.yml
@@ -90,6 +90,7 @@ components:
       required: false
       schema:
         type: string
+        nullable: true
       examples:
         X1:
           value: en


### PR DESCRIPTION
Added attribute that tell that the lang parameter must not be specified. 
Although you have to specify it nullableReferenceTypes when generatin the server for it to actually generat nullable types.

E.g. by using openapi-generator-cli  docker image as

`docker run --rm -v %cd%:/local openapitools/openapi-generator-cli generate -i https://raw.githubusercontent.com/petroslikidis/PxApiSpecs/nullable-lang-fix/PxAPI-2.yml -g aspnetcore -o /local/out/pxapi2_0_take4 --additional-properties='aspnetCoreVersion=6.0' --additional-properties=nullableReferenceTypes=true`

and not be using the the editor.swagger.io service.