### PR TITLE
Changes for jsonstat2

### DIFF
--- a/PxAPI-2.yml
+++ b/PxAPI-2.yml
@@ -899,6 +899,7 @@ components:
         discontinued:
           description: Table will no longer be updated
           type: boolean
+          nullable: true
         contact:
           type: array
           description: A list of contacts associated with the table.
@@ -1053,8 +1054,6 @@ components:
           "$ref": "#/components/schemas/updated"
         link:
           "$ref": "#/components/schemas/jsonstat-link"
-        extension:
-          "$ref": "#/components/schemas/extension-root"  
         role:
           description: Specification on json-stat.org -> [here](https://json-stat.org/full/#role)
           type: object
@@ -1094,12 +1093,15 @@ components:
               link:
                 "$ref": "#/components/schemas/jsonstat-extension-link"
              additionalProperties: false            
+        extension:
+          "$ref": "#/components/schemas/extension-root"  
         value:
           description: Specification on json-stat.org -> [here](https://json-stat.org/full/#value)
           type: array
           nullable: true
           items:
             type: number
+            format: double
         status:
           description: Specification on json-stat.org -> [here](https://json-stat.org/full/#status)
           type: object


### PR DESCRIPTION
Nullable set to true for discontinued.
Moved extension for root after dimension.
Specified format to double for value array.